### PR TITLE
do not call replace on object properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,10 @@ module.exports = {
         if (config.css && config.css.length > 0) {
           var temp;
           for (var i in config.css) {
-            temp = config.css[i].replace('../', '');
-            updateElements += '<link rel="stylesheet" type="text/css" href="' + resolvePath(temp) +'">';
+            if (config.css.hasOwnProperty(i)) {
+              temp = config.css[i].replace('../', '');
+              updateElements += '<link rel="stylesheet" type="text/css" href="' + resolvePath(temp) +'">';
+            }
           }
         }
         return updateElements;


### PR DESCRIPTION
I came across this bug on OS X 10.9.4 on my machine. I expected config.css to be an array of strings, and for line 36 to loop over an array of strings. config.css is an object and uses 'i' as object properties when it should only be only used as an integer representing the index.

Specifically it fixes this bug:
Template render error: (/Users/my-username/.gitbook/versions/2.0.1/theme/templates/website/page.html) [Line 20, Column 20]
  Template render error: Template render error: Template render error: Template render error: TypeError: Object Array has no method 'replace' (In file 'README.md')
